### PR TITLE
fix: No such class errors in Java agent on Linux with Java 17

### DIFF
--- a/agent-instrumentation/build.gradle.kts
+++ b/agent-instrumentation/build.gradle.kts
@@ -130,7 +130,7 @@ kotlin {
         val runtimeJar by registering(ShadowJar::class) {
             mergeServiceFiles()
             isZip64 = true
-            archiveFileName.set("drillRuntime.jar")
+            archiveFileName.set("drill-runtime.jar")
             from(jvmMainCompilation.runtimeDependencyFiles, jvmMainCompilation.output, jvmIntTestCompilation.output.classesDirs)
             dependencies {
                 exclude("/META-INF/services/javax.servlet.ServletContainerInitializer")

--- a/agent-instrumentation/src/commonIntTest/kotlin/com/epam/drill/agent/instrument/TestClassPathProvider.kt
+++ b/agent-instrumentation/src/commonIntTest/kotlin/com/epam/drill/agent/instrument/TestClassPathProvider.kt
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2020 - 2022 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.drill.agent.instrument
+
+expect object TestClassPathProvider : ClassPathProvider

--- a/agent-instrumentation/src/commonMain/kotlin/com/epam/drill/agent/instrument/ClassPathProvider.kt
+++ b/agent-instrumentation/src/commonMain/kotlin/com/epam/drill/agent/instrument/ClassPathProvider.kt
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2020 - 2022 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.drill.agent.instrument
+
+interface ClassPathProvider {
+    fun getClassPath(): String
+}

--- a/agent-instrumentation/src/jvmIntTest/kotlin/com/epam/drill/agent/instrument/TestClassPathProvider.kt
+++ b/agent-instrumentation/src/jvmIntTest/kotlin/com/epam/drill/agent/instrument/TestClassPathProvider.kt
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2020 - 2022 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.drill.agent.instrument
+
+actual object TestClassPathProvider : ClassPathProvider {
+    external override fun getClassPath(): String
+}

--- a/agent-instrumentation/src/jvmIntTest/kotlin/com/epam/drill/agent/instrument/transformers/clients/ApacheHttpClientTransformer.kt
+++ b/agent-instrumentation/src/jvmIntTest/kotlin/com/epam/drill/agent/instrument/transformers/clients/ApacheHttpClientTransformer.kt
@@ -15,8 +15,10 @@
  */
 package com.epam.drill.agent.instrument.transformers.clients
 
+import com.epam.drill.agent.instrument.ClassPathProvider
 import com.epam.drill.agent.instrument.DrillRequestHeadersProcessor
 import com.epam.drill.agent.instrument.HeadersProcessor
+import com.epam.drill.agent.instrument.TestClassPathProvider
 import com.epam.drill.agent.instrument.TestHeadersRetriever
 import com.epam.drill.agent.instrument.TestRequestHolder
 import com.epam.drill.agent.instrument.TransformerObject
@@ -25,4 +27,5 @@ import com.epam.drill.agent.instrument.clients.ApacheHttpClientTransformerObject
 actual object ApacheHttpClientTransformer :
     TransformerObject,
     ApacheHttpClientTransformerObject(),
-    HeadersProcessor by DrillRequestHeadersProcessor(TestHeadersRetriever, TestRequestHolder)
+    HeadersProcessor by DrillRequestHeadersProcessor(TestHeadersRetriever, TestRequestHolder),
+    ClassPathProvider by TestClassPathProvider

--- a/agent-instrumentation/src/jvmIntTest/kotlin/com/epam/drill/agent/instrument/transformers/clients/JavaHttpClientTransformer.kt
+++ b/agent-instrumentation/src/jvmIntTest/kotlin/com/epam/drill/agent/instrument/transformers/clients/JavaHttpClientTransformer.kt
@@ -15,8 +15,10 @@
  */
 package com.epam.drill.agent.instrument.transformers.clients
 
+import com.epam.drill.agent.instrument.ClassPathProvider
 import com.epam.drill.agent.instrument.DrillRequestHeadersProcessor
 import com.epam.drill.agent.instrument.HeadersProcessor
+import com.epam.drill.agent.instrument.TestClassPathProvider
 import com.epam.drill.agent.instrument.TestHeadersRetriever
 import com.epam.drill.agent.instrument.TestRequestHolder
 import com.epam.drill.agent.instrument.TransformerObject
@@ -25,4 +27,5 @@ import com.epam.drill.agent.instrument.clients.JavaHttpClientTransformerObject
 actual object JavaHttpClientTransformer :
     TransformerObject,
     JavaHttpClientTransformerObject(),
-    HeadersProcessor by DrillRequestHeadersProcessor(TestHeadersRetriever, TestRequestHolder)
+    HeadersProcessor by DrillRequestHeadersProcessor(TestHeadersRetriever, TestRequestHolder),
+    ClassPathProvider by TestClassPathProvider

--- a/agent-instrumentation/src/jvmIntTest/kotlin/com/epam/drill/agent/instrument/transformers/clients/OkHttp3ClientTransformer.kt
+++ b/agent-instrumentation/src/jvmIntTest/kotlin/com/epam/drill/agent/instrument/transformers/clients/OkHttp3ClientTransformer.kt
@@ -15,8 +15,10 @@
  */
 package com.epam.drill.agent.instrument.transformers.clients
 
+import com.epam.drill.agent.instrument.ClassPathProvider
 import com.epam.drill.agent.instrument.DrillRequestHeadersProcessor
 import com.epam.drill.agent.instrument.HeadersProcessor
+import com.epam.drill.agent.instrument.TestClassPathProvider
 import com.epam.drill.agent.instrument.TestHeadersRetriever
 import com.epam.drill.agent.instrument.TestRequestHolder
 import com.epam.drill.agent.instrument.TransformerObject
@@ -25,4 +27,5 @@ import com.epam.drill.agent.instrument.clients.OkHttp3ClientTransformerObject
 actual object OkHttp3ClientTransformer :
     TransformerObject,
     OkHttp3ClientTransformerObject(),
-    HeadersProcessor by DrillRequestHeadersProcessor(TestHeadersRetriever, TestRequestHolder)
+    HeadersProcessor by DrillRequestHeadersProcessor(TestHeadersRetriever, TestRequestHolder),
+    ClassPathProvider by TestClassPathProvider

--- a/agent-instrumentation/src/jvmIntTest/kotlin/com/epam/drill/agent/instrument/transformers/servers/KafkaTransformer.kt
+++ b/agent-instrumentation/src/jvmIntTest/kotlin/com/epam/drill/agent/instrument/transformers/servers/KafkaTransformer.kt
@@ -15,8 +15,10 @@
  */
 package com.epam.drill.agent.instrument.transformers.servers
 
+import com.epam.drill.agent.instrument.ClassPathProvider
 import com.epam.drill.agent.instrument.DrillRequestHeadersProcessor
 import com.epam.drill.agent.instrument.HeadersProcessor
+import com.epam.drill.agent.instrument.TestClassPathProvider
 import com.epam.drill.agent.instrument.TestHeadersRetriever
 import com.epam.drill.agent.instrument.TestRequestHolder
 import com.epam.drill.agent.instrument.TransformerObject
@@ -25,4 +27,5 @@ import com.epam.drill.agent.instrument.servers.KafkaTransformerObject
 actual object KafkaTransformer :
     TransformerObject,
     KafkaTransformerObject(),
-    HeadersProcessor by DrillRequestHeadersProcessor(TestHeadersRetriever, TestRequestHolder)
+    HeadersProcessor by DrillRequestHeadersProcessor(TestHeadersRetriever, TestRequestHolder),
+    ClassPathProvider by TestClassPathProvider

--- a/agent-instrumentation/src/jvmIntTest/kotlin/com/epam/drill/agent/instrument/transformers/servers/NettyTransformer.kt
+++ b/agent-instrumentation/src/jvmIntTest/kotlin/com/epam/drill/agent/instrument/transformers/servers/NettyTransformer.kt
@@ -15,8 +15,10 @@
  */
 package com.epam.drill.agent.instrument.transformers.servers
 
+import com.epam.drill.agent.instrument.ClassPathProvider
 import com.epam.drill.agent.instrument.DrillRequestHeadersProcessor
 import com.epam.drill.agent.instrument.HeadersProcessor
+import com.epam.drill.agent.instrument.TestClassPathProvider
 import com.epam.drill.agent.instrument.TestHeadersRetriever
 import com.epam.drill.agent.instrument.TestRequestHolder
 import com.epam.drill.agent.instrument.TransformerObject
@@ -25,4 +27,5 @@ import com.epam.drill.agent.instrument.servers.NettyTransformerObject
 actual object NettyTransformer :
     TransformerObject,
     NettyTransformerObject(TestHeadersRetriever),
-    HeadersProcessor by DrillRequestHeadersProcessor(TestHeadersRetriever, TestRequestHolder)
+    HeadersProcessor by DrillRequestHeadersProcessor(TestHeadersRetriever, TestRequestHolder),
+    ClassPathProvider by TestClassPathProvider

--- a/agent-instrumentation/src/jvmIntTest/kotlin/com/epam/drill/agent/instrument/transformers/servers/SSLEngineTransformer.kt
+++ b/agent-instrumentation/src/jvmIntTest/kotlin/com/epam/drill/agent/instrument/transformers/servers/SSLEngineTransformer.kt
@@ -15,8 +15,10 @@
  */
 package com.epam.drill.agent.instrument.transformers.servers
 
+import com.epam.drill.agent.instrument.ClassPathProvider
 import com.epam.drill.agent.instrument.DrillRequestHeadersProcessor
 import com.epam.drill.agent.instrument.HeadersProcessor
+import com.epam.drill.agent.instrument.TestClassPathProvider
 import com.epam.drill.agent.instrument.TestHeadersRetriever
 import com.epam.drill.agent.instrument.TestRequestHolder
 import com.epam.drill.agent.instrument.TransformerObject
@@ -25,4 +27,5 @@ import com.epam.drill.agent.instrument.servers.SSLEngineTransformerObject
 actual object SSLEngineTransformer :
     TransformerObject,
     SSLEngineTransformerObject(TestHeadersRetriever),
-    HeadersProcessor by DrillRequestHeadersProcessor(TestHeadersRetriever, TestRequestHolder)
+    HeadersProcessor by DrillRequestHeadersProcessor(TestHeadersRetriever, TestRequestHolder),
+    ClassPathProvider by TestClassPathProvider

--- a/agent-instrumentation/src/jvmIntTest/kotlin/com/epam/drill/agent/instrument/transformers/servers/TomcatTransformer.kt
+++ b/agent-instrumentation/src/jvmIntTest/kotlin/com/epam/drill/agent/instrument/transformers/servers/TomcatTransformer.kt
@@ -15,8 +15,10 @@
  */
 package com.epam.drill.agent.instrument.transformers.servers
 
+import com.epam.drill.agent.instrument.ClassPathProvider
 import com.epam.drill.agent.instrument.DrillRequestHeadersProcessor
 import com.epam.drill.agent.instrument.HeadersProcessor
+import com.epam.drill.agent.instrument.TestClassPathProvider
 import com.epam.drill.agent.instrument.TestHeadersRetriever
 import com.epam.drill.agent.instrument.TestRequestHolder
 import com.epam.drill.agent.instrument.TransformerObject
@@ -25,4 +27,5 @@ import com.epam.drill.agent.instrument.servers.TomcatTransformerObject
 actual object TomcatTransformer :
     TransformerObject,
     TomcatTransformerObject(TestHeadersRetriever),
-    HeadersProcessor by DrillRequestHeadersProcessor(TestHeadersRetriever, TestRequestHolder)
+    HeadersProcessor by DrillRequestHeadersProcessor(TestHeadersRetriever, TestRequestHolder),
+    ClassPathProvider by TestClassPathProvider

--- a/agent-instrumentation/src/nativeIntTest/kotlin/com/epam/drill/agent/instrument/TestClassPathProvider.kt
+++ b/agent-instrumentation/src/nativeIntTest/kotlin/com/epam/drill/agent/instrument/TestClassPathProvider.kt
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2020 - 2022 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.epam.drill.agent.instrument
+
+actual object TestClassPathProvider : ClassPathProvider {
+    override fun getClassPath() = runtimeJarPath.value
+}


### PR DESCRIPTION
- Implemented classpath adjustment for javaassist

Refs: EPMDJ-10772